### PR TITLE
Fix: Correct profile picture location and update gradients

### DIFF
--- a/src/components/Aboutme.jsx
+++ b/src/components/Aboutme.jsx
@@ -17,8 +17,8 @@ function Aboutme() {
           About me
         </div>
         <div className="flex gap-5">
-          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
-          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
 
         </div>
 

--- a/src/components/Contactme.jsx
+++ b/src/components/Contactme.jsx
@@ -103,8 +103,8 @@ function Contactme() {
           Contact me
         </div>
         <div className="flex gap-5">
-          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
-          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
 
         </div>
 

--- a/src/components/Git.jsx
+++ b/src/components/Git.jsx
@@ -10,8 +10,8 @@ function Git() {
                     nimeth02
                 </Link>
                 <div className="flex gap-5">
-                    <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
-                    <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+                    <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+                    <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
 
                 </div>
             </div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -15,8 +15,8 @@ function Projects() {
           Projects
         </div>
         <div className="flex gap-5">
-          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
-          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
 
         </div>
 

--- a/src/components/Technology.jsx
+++ b/src/components/Technology.jsx
@@ -10,8 +10,8 @@ function Technology() {
           Technologies
         </div>
         <div className="flex gap-5">
-          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
-          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[150px] md:w-[250px] lg:w-[350px] h-[10px] lg:h-[15px] bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+          <div className=" w-[20px] h-[10px] lg:h-[15px]   bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
 
         </div>
         {/* <div>

--- a/src/components/profile.jsx
+++ b/src/components/profile.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import profile from '../../public/profile.svg'
 import Image from 'next/image'
 import { Typography } from '@material-tailwind/react'
 
@@ -8,7 +9,7 @@ function Profile() {
             <div className="lg:mt-20">
                 <div className="flex flex-col md:flex-row-reverse justify-between 2xl:pr-40 items-center">
                     <div className="flex justify-center ">
-                        <Image alt="Image P1" src="https://github.com/nimeth02.png" className="h-[300px] md:h-[500px]" />
+                        <Image alt="Image P1" src={profile} className="h-[300px] md:h-[500px]" />
                     </div>
                     <div className="flex flex-col gap-4 lg:gap-10 p-4">
                         <div className="font-semibold tracking-wide text-lg lg:text-2xl xl:text-3xl ">
@@ -19,8 +20,8 @@ function Profile() {
                             <div className='text-bt  w-[250px]  lg:w-[420px] xl:w-[490px]'>I am a Software Developer</div> 
                         </div>
                         <div className="flex gap-5">
-                            <div className=" h-[10px] lg:h-[15px] w-[200%]  bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
-                            <div className=" h-[10px] lg:h-[15px] w-[10%]  bg-gradient-to-r from-cyan-500 to-blue-500  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+                            <div className=" h-[10px] lg:h-[15px] w-[200%]  bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
+                            <div className=" h-[10px] lg:h-[15px] w-[10%]  bg-gradient-to-r from-green-400 to-green-600  rounded drop-shadow-[0px_0px_5px_rgba(255,255,255,0.6)]" ></div>
 
                         </div>
                     </div>

--- a/src/components/welcome.jsx
+++ b/src/components/welcome.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import welcome from '../../public/welcome.png'
 import Image from 'next/image'
 import { Typography } from '@material-tailwind/react'
 import Link from 'next/link'
@@ -13,7 +12,7 @@ function Welcome() {
             
             <div className="flex gap-20 " id="home">
                 <div className='relative flex-2 items-center  '>
-                    <Image alt="Image P1" src={welcome} className="z-10 border-2 border-bg absolute bottom right-4 flex-1   bg-bg2 rounded-full  h-[300px] w-[300px] " />
+                    <Image alt="Image P1" src="https://github.com/nimeth02.png" className="z-10 border-2 border-bg absolute bottom right-4 flex-1   bg-bg2 rounded-full  h-[300px] w-[300px] " />
                     <div className=' bg-bt h-[300px] w-[300px] rounded-full'></div>
                     {/* <div className="relative w-[300px] h-[300px]">
                         <div className="triangle  absolute bottom-0 left-1/2 transform -translate-x-1/2"></div>


### PR DESCRIPTION
This commit addresses your feedback on the previous theme update:

1.  **Profile Picture Location Corrected:**
    *   The profile picture displayed in `src/components/welcome.jsx` has been updated to use the GitHub profile URL: `https://github.com/nimeth02.png`.
    *   The image in `src/components/profile.jsx` has been reverted to use the local `profile.svg`.

2.  **Gradient Line Colors Updated Globally:**
    *   In components `profile.jsx`, `Aboutme.jsx`, `Contactme.jsx`, `Git.jsx`, `Projects.jsx`, and `Technology.jsx`, the under-title gradient lines have been changed from `bg-gradient-to-r from-cyan-500 to-blue-500` to `bg-gradient-to-r from-green-400 to-green-600`.

These changes ensure the theme update aligns with your specific component structure and styling preferences. The overall green theme and animation integrity from the previous commit are maintained.