### PR TITLE
Fix: Update profile picture URL in welcome.jsx

### DIFF
--- a/src/components/welcome.jsx
+++ b/src/components/welcome.jsx
@@ -12,7 +12,7 @@ function Welcome() {
             
             <div className="flex gap-20 " id="home">
                 <div className='relative flex-2 items-center  '>
-                    <Image alt="Image P1" src="https://github.com/nimeth02.png" className="z-10 border-2 border-bg absolute bottom right-4 flex-1   bg-bg2 rounded-full  h-[300px] w-[300px] " />
+                    <Image alt="Image P1" src="https://avatars.githubusercontent.com/u/90857630?v=4" className="z-10 border-2 border-bg absolute bottom right-4 flex-1   bg-bg2 rounded-full  h-[300px] w-[300px] " />
                     <div className=' bg-bt h-[300px] w-[300px] rounded-full'></div>
                     {/* <div className="relative w-[300px] h-[300px]">
                         <div className="triangle  absolute bottom-0 left-1/2 transform -translate-x-1/2"></div>


### PR DESCRIPTION
This commit updates the URL for the profile picture in `src/components/welcome.jsx` to the direct link you provided: `https://avatars.githubusercontent.com/u/90857630?v=4`.

This ensures the correct profile image is displayed. All other theme and structural changes from previous commits remain unaffected.